### PR TITLE
Remove enumerate from dataset iterations

### DIFF
--- a/notebooks/2-mnist-with-keras-eager-and-tf-data.ipynb
+++ b/notebooks/2-mnist-with-keras-eager-and-tf-data.ipynb
@@ -1,1 +1,300 @@
-{"nbformat":4,"nbformat_minor":0,"metadata":{"colab":{"name":"2-mnist-with-keras-eager-and-tf-data.ipynb","version":"0.3.2","views":{},"default_view":{},"provenance":[],"collapsed_sections":[]}},"cells":[{"metadata":{"id":"2-B5UZxUchfd","colab_type":"text"},"cell_type":"markdown","source":["# MNIST with tf.keras, tf.data, and eager execution.\n","\n","In this lab, you'll learn how create a `tf.data` [Dataset](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) for the MNIST dataset. The tf.data API provides tools for working with data (including common functionaltity, like shuffling, batching, etc), as well as high performance utilities (like parallel reads, and pre-fecthing to GPUs) - should you need these down the road. Here, we'll wrap MNIST with tf.data, just to introduce the API. Later, you'll learn how to use tf.data on your own data, say, to read a directory of images off disk.\n","\n","To learn more about tf.data, you can check out [this](https://www.youtube.com/watch?v=EHHdyM3NNiA&index=26&list=PLQY2H8rRoyvxjVx3zfw4vA4cvlKogyLNN) talk from the [2018 TensorFlow Developer Summit](https://www.tensorflow.org/dev-summit/).\n","\n","The rest of the code similar to the previous notebook, with three changes. \n","\n","1) Instead of using `model.fit`, we use `model.train_on_batch` as we iterate over our dataset. \n","2) We will create a TensorFlow optimizer to pass to the Keras model.\n","3) We will enable eager execution.\n","\n","### Eager execution\n","Eager execution is a mode for running TensorFlow that works just like regular Python. To learn more about eager, check out [this talk](https://www.youtube.com/watch?v=T8AW0fKP0Hs&list=PLQY2H8rRoyvxjVx3zfw4vA4cvlKogyLNN&index=8)."]},{"metadata":{"id":"902Rjd5DZroO","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["!pip install -q -U tensorflow==1.8.0\n","import tensorflow as tf\n","\n","# Enable eager execution\n","tf.enable_eager_execution()\n","\n","import numpy as np"],"execution_count":0,"outputs":[]},{"metadata":{"id":"evWlYUkYefG8","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["(train_images, train_labels), (test_images, test_labels) = tf.keras.datasets.mnist.load_data()"],"execution_count":0,"outputs":[]},{"metadata":{"id":"JA3braIeeggc","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["TRAINING_SIZE = len(train_images)\n","TEST_SIZE = len(test_images)\n","\n","# Reshape from (N, 28, 28) to (N, 784)\n","train_images = np.reshape(train_images, (TRAINING_SIZE, 784))\n","test_images = np.reshape(test_images, (TEST_SIZE, 784))\n","\n","# Convert the array to float32 as opposed to uint8\n","train_images = train_images.astype(np.float32)\n","test_images = test_images.astype(np.float32)\n","\n","# Convert the pixel values from integers between 0 and 255 to floats between 0 and 1\n","train_images /= 255\n","test_images /=  255"],"execution_count":0,"outputs":[]},{"metadata":{"id":"wbwRqi0BeicT","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["NUM_DIGITS = 10\n","\n","print(\"Before\", train_labels[0]) # The format of the labels before conversion\n","\n","train_labels  = tf.keras.utils.to_categorical(train_labels, NUM_DIGITS)\n","\n","print(\"After\", train_labels[0]) # The format of the labels after conversion\n","\n","test_labels = tf.keras.utils.to_categorical(test_labels, NUM_DIGITS)"],"execution_count":0,"outputs":[]},{"metadata":{"id":"XFtvnaI5jU_5","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["# Cast the labels to floats, needed later\n","train_labels = train_labels.astype(np.float32)\n","test_labels = test_labels.astype(np.float32)"],"execution_count":0,"outputs":[]},{"metadata":{"id":"jjNr3gr3ejh2","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["model = tf.keras.Sequential()\n","model.add(tf.keras.layers.Dense(512, activation=tf.nn.relu, input_shape=(784,)))\n","model.add(tf.keras.layers.Dense(10, activation=tf.nn.softmax))\n","\n","\n","# Create a TensorFlow optimizer, rather than using the Keras version\n","# This is currently necessary when working in eager mode\n","optimizer = tf.train.RMSPropOptimizer(learning_rate=0.001)\n","\n","# We will now compile and print out a summary of our model\n","model.compile(loss='categorical_crossentropy',\n","              optimizer=optimizer,\n","              metrics=['accuracy'])\n","\n","model.summary()"],"execution_count":0,"outputs":[]},{"metadata":{"id":"zUZPvDQYe5Xu","colab_type":"text"},"cell_type":"markdown","source":["### Step 1) Create a tf.data Dataset\n","\n","Here, we'll use the `tf.data.Dataset` [API](https://www.tensorflow.org/api_docs/python/tf/data) to convert the Numpy arrays into a TensorFlow dataset.\n","\n","Next, we will create a simple for loop that will serve as our introduction into creating custom training loops. Although this essentially does the same thing as `model.fit` it allows us to get creative and customize the overall training process (should you like to, if you venture into research) and collect different metrics throughout the process."]},{"metadata":{"id":"sdBd2pd_fdue","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["BATCH_SIZE=128\n","\n","# Because tf.data may work with potentially **large** collections of data\n","# we do not shuffle the entire dataset by default\n","# Instead, we maintain a buffer of SHUFFLE_SIZE elements\n","# and sample from there.\n","SHUFFLE_SIZE = 10000 \n","\n","# Create the dataset\n","dataset = tf.data.Dataset.from_tensor_slices((train_images, train_labels))\n","dataset = dataset.shuffle(SHUFFLE_SIZE)\n","dataset = dataset.batch(BATCH_SIZE)"],"execution_count":0,"outputs":[]},{"metadata":{"id":"ksAR-C6xgUu4","colab_type":"text"},"cell_type":"markdown","source":["### Step 2) Iterate over the dataset\n","Here, we'll iterate over the dataset, and train our model using `model.train_on_batch`. To learn more about the elements returned from the dataset, you can print them out and try the `.numpy()` method.\n"]},{"metadata":{"id":"kNgnUKPvgSCz","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["EPOCHS=5\n","\n","for epoch in range(EPOCHS):\n","  for (batch, (images, labels)) in enumerate(dataset):\n","    train_loss, train_accuracy = model.train_on_batch(images, labels)\n","  \n","  # Here you can gather any metrics or adjust your training parameters\n","  print('Epoch #%d\\t Loss: %.6f\\tAccuracy: %.6f' % (epoch + 1, train_loss, train_accuracy))\n","  "],"execution_count":0,"outputs":[]},{"metadata":{"id":"tg5U3Iqkgo3J","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["loss, accuracy = model.evaluate(test_images, test_labels)\n","print('Test accuracy: %.2f' % (accuracy))"],"execution_count":0,"outputs":[]},{"metadata":{"id":"Fu0eSNa9kEFZ","colab_type":"text"},"cell_type":"markdown","source":["### Congratulations\n","You have trained a model on MNIST using Keras, eager execution, and tf.data."]}]}
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "2-mnist-with-keras-eager-and-tf-data.ipynb",
+      "version": "0.3.2",
+      "views": {},
+      "default_view": {},
+      "provenance": [],
+      "collapsed_sections": []
+    }
+  },
+  "cells": [
+    {
+      "metadata": {
+        "id": "2-B5UZxUchfd",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "# MNIST with tf.keras, tf.data, and eager execution.\n",
+        "\n",
+        "In this lab, you'll learn how create a `tf.data` [Dataset](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) for the MNIST dataset. The tf.data API provides tools for working with data (including common functionaltity, like shuffling, batching, etc), as well as high performance utilities (like parallel reads, and pre-fecthing to GPUs) - should you need these down the road. Here, we'll wrap MNIST with tf.data, just to introduce the API. Later, you'll learn how to use tf.data on your own data, say, to read a directory of images off disk.\n",
+        "\n",
+        "To learn more about tf.data, you can check out [this](https://www.youtube.com/watch?v=EHHdyM3NNiA&index=26&list=PLQY2H8rRoyvxjVx3zfw4vA4cvlKogyLNN) talk from the [2018 TensorFlow Developer Summit](https://www.tensorflow.org/dev-summit/).\n",
+        "\n",
+        "The rest of the code similar to the previous notebook, with three changes. \n",
+        "\n",
+        "1) Instead of using `model.fit`, we use `model.train_on_batch` as we iterate over our dataset. \n",
+        "2) We will create a TensorFlow optimizer to pass to the Keras model.\n",
+        "3) We will enable eager execution.\n",
+        "\n",
+        "### Eager execution\n",
+        "Eager execution is a mode for running TensorFlow that works just like regular Python. To learn more about eager, check out [this talk](https://www.youtube.com/watch?v=T8AW0fKP0Hs&list=PLQY2H8rRoyvxjVx3zfw4vA4cvlKogyLNN&index=8)."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "902Rjd5DZroO",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "!pip install -q -U tensorflow==1.8.0\n",
+        "import tensorflow as tf\n",
+        "\n",
+        "# Enable eager execution\n",
+        "tf.enable_eager_execution()\n",
+        "\n",
+        "import numpy as np"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "evWlYUkYefG8",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "(train_images, train_labels), (test_images, test_labels) = tf.keras.datasets.mnist.load_data()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "JA3braIeeggc",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "TRAINING_SIZE = len(train_images)\n",
+        "TEST_SIZE = len(test_images)\n",
+        "\n",
+        "# Reshape from (N, 28, 28) to (N, 784)\n",
+        "train_images = np.reshape(train_images, (TRAINING_SIZE, 784))\n",
+        "test_images = np.reshape(test_images, (TEST_SIZE, 784))\n",
+        "\n",
+        "# Convert the array to float32 as opposed to uint8\n",
+        "train_images = train_images.astype(np.float32)\n",
+        "test_images = test_images.astype(np.float32)\n",
+        "\n",
+        "# Convert the pixel values from integers between 0 and 255 to floats between 0 and 1\n",
+        "train_images /= 255\n",
+        "test_images /=  255"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "wbwRqi0BeicT",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "NUM_DIGITS = 10\n",
+        "\n",
+        "print(\"Before\", train_labels[0]) # The format of the labels before conversion\n",
+        "\n",
+        "train_labels  = tf.keras.utils.to_categorical(train_labels, NUM_DIGITS)\n",
+        "\n",
+        "print(\"After\", train_labels[0]) # The format of the labels after conversion\n",
+        "\n",
+        "test_labels = tf.keras.utils.to_categorical(test_labels, NUM_DIGITS)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "XFtvnaI5jU_5",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "# Cast the labels to floats, needed later\n",
+        "train_labels = train_labels.astype(np.float32)\n",
+        "test_labels = test_labels.astype(np.float32)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "jjNr3gr3ejh2",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "model = tf.keras.Sequential()\n",
+        "model.add(tf.keras.layers.Dense(512, activation=tf.nn.relu, input_shape=(784,)))\n",
+        "model.add(tf.keras.layers.Dense(10, activation=tf.nn.softmax))\n",
+        "\n",
+        "\n",
+        "# Create a TensorFlow optimizer, rather than using the Keras version\n",
+        "# This is currently necessary when working in eager mode\n",
+        "optimizer = tf.train.RMSPropOptimizer(learning_rate=0.001)\n",
+        "\n",
+        "# We will now compile and print out a summary of our model\n",
+        "model.compile(loss='categorical_crossentropy',\n",
+        "              optimizer=optimizer,\n",
+        "              metrics=['accuracy'])\n",
+        "\n",
+        "model.summary()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "zUZPvDQYe5Xu",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 1) Create a tf.data Dataset\n",
+        "\n",
+        "Here, we'll use the `tf.data.Dataset` [API](https://www.tensorflow.org/api_docs/python/tf/data) to convert the Numpy arrays into a TensorFlow dataset.\n",
+        "\n",
+        "Next, we will create a simple for loop that will serve as our introduction into creating custom training loops. Although this essentially does the same thing as `model.fit` it allows us to get creative and customize the overall training process (should you like to, if you venture into research) and collect different metrics throughout the process."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "sdBd2pd_fdue",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "BATCH_SIZE=128\n",
+        "\n",
+        "# Because tf.data may work with potentially **large** collections of data\n",
+        "# we do not shuffle the entire dataset by default\n",
+        "# Instead, we maintain a buffer of SHUFFLE_SIZE elements\n",
+        "# and sample from there.\n",
+        "SHUFFLE_SIZE = 10000 \n",
+        "\n",
+        "# Create the dataset\n",
+        "dataset = tf.data.Dataset.from_tensor_slices((train_images, train_labels))\n",
+        "dataset = dataset.shuffle(SHUFFLE_SIZE)\n",
+        "dataset = dataset.batch(BATCH_SIZE)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "ksAR-C6xgUu4",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 2) Iterate over the dataset\n",
+        "Here, we'll iterate over the dataset, and train our model using `model.train_on_batch`. To learn more about the elements returned from the dataset, you can print them out and try the `.numpy()` method.\n"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "kNgnUKPvgSCz",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "EPOCHS=5\n",
+        "\n",
+        "for epoch in range(EPOCHS):\n",
+        "  for images, labels in dataset:\n",
+        "    train_loss, train_accuracy = model.train_on_batch(images, labels)\n",
+        "  \n",
+        "  # Here you can gather any metrics or adjust your training parameters\n",
+        "  print('Epoch #%d\\t Loss: %.6f\\tAccuracy: %.6f' % (epoch + 1, train_loss, train_accuracy))\n",
+        "  "
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "tg5U3Iqkgo3J",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "loss, accuracy = model.evaluate(test_images, test_labels)\n",
+        "print('Test accuracy: %.2f' % (accuracy))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "Fu0eSNa9kEFZ",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Congratulations\n",
+        "You have trained a model on MNIST using Keras, eager execution, and tf.data."
+      ]
+    }
+  ]
+}

--- a/notebooks/3-imdb.ipynb
+++ b/notebooks/3-imdb.ipynb
@@ -1,1 +1,520 @@
-{"nbformat":4,"nbformat_minor":0,"metadata":{"colab":{"name":"3-imdb.ipynb","version":"0.3.2","views":{},"default_view":{},"provenance":[],"collapsed_sections":[]}},"cells":[{"metadata":{"id":"ItXfxkxvosLH","colab_type":"text"},"cell_type":"markdown","source":["# Classifying movie reviews with tf.keras, tf.data, and eager execution.\n","\n","In this lab you'll learn how to classify a movie review as positive or negative on the [IMDB dataset](https://www.tensorflow.org/api_docs/python/tf/keras/datasets/imdb). This tutorial was inspired by [this work](https://github.com/fchollet/deep-learning-with-python-notebooks/blob/master/3.5-classifying-movie-reviews.ipynb). Here, we'll use tf.keras and tf.data."]},{"metadata":{"id":"2ew7HTbPpCJH","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["!pip install -q -U tensorflow==1.8.0\n","import tensorflow as tf\n","\n","# Enable eager execution\n","tf.enable_eager_execution()\n","\n","import numpy as np"],"execution_count":0,"outputs":[]},{"metadata":{"id":"iAsKG535pHep","colab_type":"text"},"cell_type":"markdown","source":["# A first look at the dataset\n","\n","### Step 1) Downloading the dataset\n","\n","The \"IMDB dataset\" is a set of around 50,000 positive or negative reviews for movies from the Internet Movie Database. Let's use the TensorFlow API to download the dataset the same way we did for MNIST. The `num_words` argument is how many of the most popular words we will keep. All other \"rare\" words will be discarded."]},{"metadata":{"id":"zXXx5Oc3pOmN","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["(train_data, train_labels), (test_data, test_labels) = tf.keras.datasets.imdb.load_data(num_words=10000)"],"execution_count":0,"outputs":[]},{"metadata":{"id":"l50X3GfjpU4r","colab_type":"text"},"cell_type":"markdown","source":["### Step 2) Exploring the dataset \n","\n","The dataset comes preprocessed. Each example is an array of integers representing the words of the movie review. Each label is either a \"0\" for negative or \"1\" for positive."]},{"metadata":{"id":"QtTS4kpEpjbi","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["print(train_data.shape)\n","print(train_labels.shape)\n","print(train_data[0])\n","print(train_labels[0])"],"execution_count":0,"outputs":[]},{"metadata":{"id":"3KmM0e64pok8","colab_type":"text"},"cell_type":"markdown","source":["\n","### Word indexing\n","\n","To prove we have limited ourselves to the 10,000 most frequent words we will iterate over all the reviews and check the maximum value. "]},{"metadata":{"id":"GvgpnR2ppqHd","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["print(max([max(review) for review in train_data]))"],"execution_count":0,"outputs":[]},{"metadata":{"id":"4wJg2FiYpuoX","colab_type":"text"},"cell_type":"markdown","source":["### Converting the integers back to words\n","\n","We can get the dictionary from `tf.keras.datasets.imdb.get_word_index` which hashes the words to their corresponding integers. Let's try and convert a review from integers back into it's original text by first reversing this dictionary and then iterating over a review and converting the integers to strings."]},{"metadata":{"id":"tr5s_1alpzop","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["# Dictionary that hashes words to their integer\n","word_to_integer = tf.keras.datasets.imdb.get_word_index()\n","\n","# Print out the first ten keys in the dictionary\n","print(word_to_integer.keys()[0:10])\n","\n","integer_to_word = dict([(value, key) for (key, value) in word_to_integer.items()])\n","\n","# Demonstrate how to find the word from an integer\n","print(integer_to_word[1])\n","print(integer_to_word[2])\n","\n","# We need to subtract 3 from the indices because 0 is \"padding\", 1 is \"start of sequence\", and 2 is \"unknown\"\n","decoded_review = ' '.join([integer_to_word.get(i - 3, 'UNK') for i in train_data[0]])\n","print(decoded_review)"],"execution_count":0,"outputs":[]},{"metadata":{"id":"lFP_XKVRp4_S","colab_type":"text"},"cell_type":"markdown","source":["### Step 3) Format the data\n","Unfortunately, we cannot just feed unformatted arrays into our neural network. We need to standardize the input. Here, we are going to multi-hot-encode our review which is an array of integers into a 10,000 dimensional vector. We will place 1's in the indices of word-integers that occur in the review, and 0's everywhere else.\n"]},{"metadata":{"id":"NG4K-OtdqC0a","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["def vectorize_sequences(sequences, dimension=10000):\n","    # Create an all-zero matrix of shape (len(sequences), dimension)\n","    results = np.zeros((len(sequences), dimension), dtype=np.float32)\n","    for i, sequence in enumerate(sequences):\n","        results[i, sequence] = 1.  # set specific indices of results[i] to 1s\n","    return results\n","\n","train_data = vectorize_sequences(train_data)\n","test_data = vectorize_sequences(test_data)\n","\n","print(train_data.shape) # length is same as before\n","print(train_data[0]) # now, multi-hot encoded\n","\n","# Vectorize the labels as well and reshape from (N, ) to (N, 1)\n","train_labels = np.reshape(np.asarray(train_labels, dtype=np.float32), (len(train_data), 1))\n","test_labels = np.reshape(np.asarray(test_labels, dtype=np.float32), (len(test_data), 1))"],"execution_count":0,"outputs":[]},{"metadata":{"id":"jeYlLZlrqYjq","colab_type":"text"},"cell_type":"markdown","source":["### Step 4) Create the model\n","\n","Now that we have vectorized input, we're ready to build our neural network. We're going to use multiple hidden layers, each with 16 hidden units. The more layers and hidden units you have, the more complicated patterns the network can recognize and learn. \n","\n","* The downside is that a large number potentially leads to [overfitting](https://developers.google.com/machine-learning/crash-course/generalization/peril-of-overfitting) by finding patterns that may only exist in your training not (and not generalize to unseen testing data down the road).\n","\n","Instead of softmax as in the previous notebook, here our last activation will be a sigmoid. This will take the output of the first two layers and \"squish\" it into a number between 0 and 1 (the network's prediction for the review)."]},{"metadata":{"id":"uVOGq_eirutM","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["# Create a model\n","model = tf.keras.Sequential()\n","\n"," # input shape here is the length of our movie review vector\n","model.add(tf.keras.layers.Dense(16, activation=tf.nn.relu, input_shape=(10000,)))\n","model.add(tf.keras.layers.Dense(16, activation=tf.nn.relu))\n","model.add(tf.keras.layers.Dense(1, activation=tf.nn.sigmoid))\n","\n","optimizer = tf.train.RMSPropOptimizer(learning_rate=0.001)\n","\n","model.compile(loss='binary_crossentropy',\n","              optimizer=optimizer,\n","              metrics=['binary_accuracy'])\n","\n","model.summary()"],"execution_count":0,"outputs":[]},{"metadata":{"id":"nIBgYoE1sCmw","colab_type":"text"},"cell_type":"markdown","source":["### Step 5) Create a validation set\n","\n","We want to test our model on data it hasn't seen before, but before we get our final test accuracy. We'll call this dataset our validation set. In practice, it's used to tune paramters like your learning rate, or the number of layers / units in your model."]},{"metadata":{"id":"CfoGOjesswbb","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["VAL_SIZE = 10000\n","\n","val_data = train_data[:VAL_SIZE]\n","partial_train_data = train_data[VAL_SIZE:]\n","\n","\n","val_labels = train_labels[:VAL_SIZE]\n","partial_train_labels = train_labels[VAL_SIZE:]"],"execution_count":0,"outputs":[]},{"metadata":{"id":"GBvKRJIts5U4","colab_type":"text"},"cell_type":"markdown","source":["### Step 6) Create a tf.data Dataset\n","As before, we're working with a small in-memory dataset, so converting to tf.data isn't essential, just good practice for down the road. See the previous notebook or the `tf.data.Dataset` [API doc](https://www.tensorflow.org/api_docs/python/tf/data) for more info."]},{"metadata":{"id":"dz9EDovvtGa6","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["BATCH_SIZE = 512\n","SHUFFLE_SIZE = 1000\n","\n","training_set = tf.data.Dataset.from_tensor_slices((partial_train_data, partial_train_labels))\n","training_set = training_set.shuffle(SHUFFLE_SIZE).batch(BATCH_SIZE)"],"execution_count":0,"outputs":[]},{"metadata":{"id":"nh9l8Cdfte8g","colab_type":"text"},"cell_type":"markdown","source":["### Step 7) Training your model\n","Now we are going to train the model. As we go, we'll keep track of the training loss, training accuracy, validation loss, and validation accuracy. \n","\n","Please be patient as this step may take a while."]},{"metadata":{"id":"_UVH5tQqtcxc","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["EPOCHS = 10\n","\n","# Store list of metric values for plotting later\n","tr_loss_list = []\n","tr_accuracy_list = []\n","val_loss_list = []\n","val_accuracy_list = []\n","\n","for epoch in range(EPOCHS):\n","  for (batch, (reviews, labels)) in enumerate(training_set):\n","    # Calculate training loss and accuracy\n","    tr_loss, tr_accuracy = model.train_on_batch(reviews, labels)\n","  \n","  # Calculate validation loss and accuracy\n","  val_loss, val_accuracy = model.evaluate(val_data, val_labels)\n","\n","  # Add to the lists\n","  tr_loss_list.append(tr_loss)\n","  tr_accuracy_list.append(tr_accuracy)\n","  val_loss_list.append(val_loss)\n","  val_accuracy_list.append(val_accuracy)\n","  \n","  print(('Epoch #%d\\t Training Loss: %.2f\\tTraining Accuracy: %.2f\\t'\n","         'Validation Loss: %.2f\\tValidation Accuracy: %.2f')\n","         % (epoch + 1, tr_loss, tr_accuracy,\n","         val_loss, val_accuracy))"],"execution_count":0,"outputs":[]},{"metadata":{"id":"xNzTBpLBvPPn","colab_type":"text"},"cell_type":"markdown","source":["### Step 8) Plotting loss and accuracy\n","We are going to use `matplotlib` to plot our training and validation metrics."]},{"metadata":{"id":"kcBHF0rKt4Rn","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["import matplotlib.pyplot as plt\n","\n","epochs = range(1, EPOCHS + 1)\n","\n","# \"bo\" specifies \"blue dot\"\n","plt.plot(epochs, tr_loss_list, 'bo', label='Training loss')\n","# b specifies a \"solid blue line\"\n","plt.plot(epochs, val_loss_list, 'b', label='Validation loss')\n","plt.title('Training and validation loss')\n","plt.xlabel('Epochs')\n","plt.ylabel('Loss')\n","plt.legend()\n","\n","plt.show()"],"execution_count":0,"outputs":[]},{"metadata":{"id":"sx1Vg_1qvT5D","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["plt.clf()   # Clear plot\n","\n","plt.plot(epochs, tr_accuracy_list, 'bo', label='Training accuracy')\n","plt.plot(epochs, val_accuracy_list, 'b', label='Validation accuracy')\n","plt.title('Training and validation accuracy')\n","plt.xlabel('Epochs')\n","plt.ylabel('Accuracy')\n","plt.legend()\n","\n","plt.show()"],"execution_count":0,"outputs":[]},{"metadata":{"id":"rX_qklYwvak2","colab_type":"text"},"cell_type":"markdown","source":["### Step 9) Testing your model\n","Now that we have successfully trained our model and our training accuracy has jumped over 95%, we need to test it on an entirely different dataset. We are going to run our model on the test set. The test accuracy is a better evaluation metric for how our model will perform in the real world. "]},{"metadata":{"id":"Oghmxes4vhs-","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["loss, accuracy = model.evaluate(test_data, test_labels)\n","print('Test accuracy: %.2f' % (accuracy))"],"execution_count":0,"outputs":[]},{"metadata":{"id":"bl7gZC_lvxyD","colab_type":"text"},"cell_type":"markdown","source":["## Congratulations\n","You have successfully trained a model on the IMDB dataset."]}]}
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "3-imdb.ipynb",
+      "version": "0.3.2",
+      "views": {},
+      "default_view": {},
+      "provenance": [],
+      "collapsed_sections": []
+    }
+  },
+  "cells": [
+    {
+      "metadata": {
+        "id": "ItXfxkxvosLH",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "# Classifying movie reviews with tf.keras, tf.data, and eager execution.\n",
+        "\n",
+        "In this lab you'll learn how to classify a movie review as positive or negative on the [IMDB dataset](https://www.tensorflow.org/api_docs/python/tf/keras/datasets/imdb). This tutorial was inspired by [this work](https://github.com/fchollet/deep-learning-with-python-notebooks/blob/master/3.5-classifying-movie-reviews.ipynb). Here, we'll use tf.keras and tf.data."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "2ew7HTbPpCJH",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "!pip install -q -U tensorflow==1.8.0\n",
+        "import tensorflow as tf\n",
+        "\n",
+        "# Enable eager execution\n",
+        "tf.enable_eager_execution()\n",
+        "\n",
+        "import numpy as np"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "iAsKG535pHep",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "# A first look at the dataset\n",
+        "\n",
+        "### Step 1) Downloading the dataset\n",
+        "\n",
+        "The \"IMDB dataset\" is a set of around 50,000 positive or negative reviews for movies from the Internet Movie Database. Let's use the TensorFlow API to download the dataset the same way we did for MNIST. The `num_words` argument is how many of the most popular words we will keep. All other \"rare\" words will be discarded."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "zXXx5Oc3pOmN",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "(train_data, train_labels), (test_data, test_labels) = tf.keras.datasets.imdb.load_data(num_words=10000)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "l50X3GfjpU4r",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 2) Exploring the dataset \n",
+        "\n",
+        "The dataset comes preprocessed. Each example is an array of integers representing the words of the movie review. Each label is either a \"0\" for negative or \"1\" for positive."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "QtTS4kpEpjbi",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "print(train_data.shape)\n",
+        "print(train_labels.shape)\n",
+        "print(train_data[0])\n",
+        "print(train_labels[0])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "3KmM0e64pok8",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "\n",
+        "### Word indexing\n",
+        "\n",
+        "To prove we have limited ourselves to the 10,000 most frequent words we will iterate over all the reviews and check the maximum value. "
+      ]
+    },
+    {
+      "metadata": {
+        "id": "GvgpnR2ppqHd",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "print(max([max(review) for review in train_data]))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "4wJg2FiYpuoX",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Converting the integers back to words\n",
+        "\n",
+        "We can get the dictionary from `tf.keras.datasets.imdb.get_word_index` which hashes the words to their corresponding integers. Let's try and convert a review from integers back into it's original text by first reversing this dictionary and then iterating over a review and converting the integers to strings."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "tr5s_1alpzop",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "# Dictionary that hashes words to their integer\n",
+        "word_to_integer = tf.keras.datasets.imdb.get_word_index()\n",
+        "\n",
+        "# Print out the first ten keys in the dictionary\n",
+        "print(word_to_integer.keys()[0:10])\n",
+        "\n",
+        "integer_to_word = dict([(value, key) for (key, value) in word_to_integer.items()])\n",
+        "\n",
+        "# Demonstrate how to find the word from an integer\n",
+        "print(integer_to_word[1])\n",
+        "print(integer_to_word[2])\n",
+        "\n",
+        "# We need to subtract 3 from the indices because 0 is \"padding\", 1 is \"start of sequence\", and 2 is \"unknown\"\n",
+        "decoded_review = ' '.join([integer_to_word.get(i - 3, 'UNK') for i in train_data[0]])\n",
+        "print(decoded_review)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "lFP_XKVRp4_S",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 3) Format the data\n",
+        "Unfortunately, we cannot just feed unformatted arrays into our neural network. We need to standardize the input. Here, we are going to multi-hot-encode our review which is an array of integers into a 10,000 dimensional vector. We will place 1's in the indices of word-integers that occur in the review, and 0's everywhere else.\n"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "NG4K-OtdqC0a",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "def vectorize_sequences(sequences, dimension=10000):\n",
+        "    # Create an all-zero matrix of shape (len(sequences), dimension)\n",
+        "    results = np.zeros((len(sequences), dimension), dtype=np.float32)\n",
+        "    for i, sequence in enumerate(sequences):\n",
+        "        results[i, sequence] = 1.  # set specific indices of results[i] to 1s\n",
+        "    return results\n",
+        "\n",
+        "train_data = vectorize_sequences(train_data)\n",
+        "test_data = vectorize_sequences(test_data)\n",
+        "\n",
+        "print(train_data.shape) # length is same as before\n",
+        "print(train_data[0]) # now, multi-hot encoded\n",
+        "\n",
+        "# Vectorize the labels as well and reshape from (N, ) to (N, 1)\n",
+        "train_labels = np.reshape(np.asarray(train_labels, dtype=np.float32), (len(train_data), 1))\n",
+        "test_labels = np.reshape(np.asarray(test_labels, dtype=np.float32), (len(test_data), 1))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "jeYlLZlrqYjq",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 4) Create the model\n",
+        "\n",
+        "Now that we have vectorized input, we're ready to build our neural network. We're going to use multiple hidden layers, each with 16 hidden units. The more layers and hidden units you have, the more complicated patterns the network can recognize and learn. \n",
+        "\n",
+        "* The downside is that a large number potentially leads to [overfitting](https://developers.google.com/machine-learning/crash-course/generalization/peril-of-overfitting) by finding patterns that may only exist in your training not (and not generalize to unseen testing data down the road).\n",
+        "\n",
+        "Instead of softmax as in the previous notebook, here our last activation will be a sigmoid. This will take the output of the first two layers and \"squish\" it into a number between 0 and 1 (the network's prediction for the review)."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "uVOGq_eirutM",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "# Create a model\n",
+        "model = tf.keras.Sequential()\n",
+        "\n",
+        " # input shape here is the length of our movie review vector\n",
+        "model.add(tf.keras.layers.Dense(16, activation=tf.nn.relu, input_shape=(10000,)))\n",
+        "model.add(tf.keras.layers.Dense(16, activation=tf.nn.relu))\n",
+        "model.add(tf.keras.layers.Dense(1, activation=tf.nn.sigmoid))\n",
+        "\n",
+        "optimizer = tf.train.RMSPropOptimizer(learning_rate=0.001)\n",
+        "\n",
+        "model.compile(loss='binary_crossentropy',\n",
+        "              optimizer=optimizer,\n",
+        "              metrics=['binary_accuracy'])\n",
+        "\n",
+        "model.summary()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "nIBgYoE1sCmw",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 5) Create a validation set\n",
+        "\n",
+        "We want to test our model on data it hasn't seen before, but before we get our final test accuracy. We'll call this dataset our validation set. In practice, it's used to tune paramters like your learning rate, or the number of layers / units in your model."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "CfoGOjesswbb",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "VAL_SIZE = 10000\n",
+        "\n",
+        "val_data = train_data[:VAL_SIZE]\n",
+        "partial_train_data = train_data[VAL_SIZE:]\n",
+        "\n",
+        "\n",
+        "val_labels = train_labels[:VAL_SIZE]\n",
+        "partial_train_labels = train_labels[VAL_SIZE:]"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "GBvKRJIts5U4",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 6) Create a tf.data Dataset\n",
+        "As before, we're working with a small in-memory dataset, so converting to tf.data isn't essential, just good practice for down the road. See the previous notebook or the `tf.data.Dataset` [API doc](https://www.tensorflow.org/api_docs/python/tf/data) for more info."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "dz9EDovvtGa6",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "BATCH_SIZE = 512\n",
+        "SHUFFLE_SIZE = 1000\n",
+        "\n",
+        "training_set = tf.data.Dataset.from_tensor_slices((partial_train_data, partial_train_labels))\n",
+        "training_set = training_set.shuffle(SHUFFLE_SIZE).batch(BATCH_SIZE)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "nh9l8Cdfte8g",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 7) Training your model\n",
+        "Now we are going to train the model. As we go, we'll keep track of the training loss, training accuracy, validation loss, and validation accuracy. \n",
+        "\n",
+        "Please be patient as this step may take a while."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "_UVH5tQqtcxc",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "EPOCHS = 10\n",
+        "\n",
+        "# Store list of metric values for plotting later\n",
+        "tr_loss_list = []\n",
+        "tr_accuracy_list = []\n",
+        "val_loss_list = []\n",
+        "val_accuracy_list = []\n",
+        "\n",
+        "for epoch in range(EPOCHS):\n",
+        "  for reviews, labels in training_set:\n",
+        "    # Calculate training loss and accuracy\n",
+        "    tr_loss, tr_accuracy = model.train_on_batch(reviews, labels)\n",
+        "  \n",
+        "  # Calculate validation loss and accuracy\n",
+        "  val_loss, val_accuracy = model.evaluate(val_data, val_labels)\n",
+        "\n",
+        "  # Add to the lists\n",
+        "  tr_loss_list.append(tr_loss)\n",
+        "  tr_accuracy_list.append(tr_accuracy)\n",
+        "  val_loss_list.append(val_loss)\n",
+        "  val_accuracy_list.append(val_accuracy)\n",
+        "  \n",
+        "  print(('Epoch #%d\\t Training Loss: %.2f\\tTraining Accuracy: %.2f\\t'\n",
+        "         'Validation Loss: %.2f\\tValidation Accuracy: %.2f')\n",
+        "         % (epoch + 1, tr_loss, tr_accuracy,\n",
+        "         val_loss, val_accuracy))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "xNzTBpLBvPPn",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 8) Plotting loss and accuracy\n",
+        "We are going to use `matplotlib` to plot our training and validation metrics."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "kcBHF0rKt4Rn",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "epochs = range(1, EPOCHS + 1)\n",
+        "\n",
+        "# \"bo\" specifies \"blue dot\"\n",
+        "plt.plot(epochs, tr_loss_list, 'bo', label='Training loss')\n",
+        "# b specifies a \"solid blue line\"\n",
+        "plt.plot(epochs, val_loss_list, 'b', label='Validation loss')\n",
+        "plt.title('Training and validation loss')\n",
+        "plt.xlabel('Epochs')\n",
+        "plt.ylabel('Loss')\n",
+        "plt.legend()\n",
+        "\n",
+        "plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "sx1Vg_1qvT5D",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "plt.clf()   # Clear plot\n",
+        "\n",
+        "plt.plot(epochs, tr_accuracy_list, 'bo', label='Training accuracy')\n",
+        "plt.plot(epochs, val_accuracy_list, 'b', label='Validation accuracy')\n",
+        "plt.title('Training and validation accuracy')\n",
+        "plt.xlabel('Epochs')\n",
+        "plt.ylabel('Accuracy')\n",
+        "plt.legend()\n",
+        "\n",
+        "plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "rX_qklYwvak2",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 9) Testing your model\n",
+        "Now that we have successfully trained our model and our training accuracy has jumped over 95%, we need to test it on an entirely different dataset. We are going to run our model on the test set. The test accuracy is a better evaluation metric for how our model will perform in the real world. "
+      ]
+    },
+    {
+      "metadata": {
+        "id": "Oghmxes4vhs-",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "loss, accuracy = model.evaluate(test_data, test_labels)\n",
+        "print('Test accuracy: %.2f' % (accuracy))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "bl7gZC_lvxyD",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Congratulations\n",
+        "You have successfully trained a model on the IMDB dataset."
+      ]
+    }
+  ]
+}

--- a/notebooks/4-reuters.ipynb
+++ b/notebooks/4-reuters.ipynb
@@ -1,1 +1,527 @@
-{"nbformat":4,"nbformat_minor":0,"metadata":{"colab":{"name":"4-reuters.ipynb","version":"0.3.2","views":{},"default_view":{},"provenance":[],"collapsed_sections":[]}},"cells":[{"metadata":{"id":"j1bsrXvzxBbl","colab_type":"text"},"cell_type":"markdown","source":["# Classifying newswires with tf.keras, tf.data, and eager execution.\n","\n","In this lab, you'll learn how to classify newswires from the [Reuters dataset](https://www.tensorflow.org/api_docs/python/tf/keras/datasets/reuters) into categories. This tutorial was inspired by [this one](https://github.com/fchollet/deep-learning-with-python-notebooks/blob/master/3.6-classifying-newswires.ipynb). This notebook is similar to previous one. The principal difference is here, we will explore a multiclass text classification problem.\n"]},{"metadata":{"id":"fGBZG7rvwf2C","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["!pip install -q -U tensorflow==1.8.0\n","import tensorflow as tf\n","\n","# Enable eager execution\n","tf.enable_eager_execution()\n","\n","import numpy as np"],"execution_count":0,"outputs":[]},{"metadata":{"id":"_39NLiiGy9ey","colab_type":"text"},"cell_type":"markdown","source":["\n","## A first look at the dataset\n","\n","### Step 1) Downloading the dataset\n","\n","The dataset consists of a set of short [newswires](https://www.google.com/search?q=what+is+a+newswire) and their corresponding topics as published by Reuters in 1986."]},{"metadata":{"id":"F-DuuRzay9KG","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["(train_data, train_labels), (test_data, test_labels) = tf.keras.datasets.reuters.load_data(num_words=10000)"],"execution_count":0,"outputs":[]},{"metadata":{"id":"arCrVEMGzR7t","colab_type":"text"},"cell_type":"markdown","source":["### Step 2) Exploring the dataset \n","\n","There are around 46 different topics. The set is divided into 8982 training examples and 2246 test examples. Each training example is a list of words represented as integers similar to the IMDB dataset, and the labels are integers up to 46."]},{"metadata":{"id":"KL6sMDLVzNpF","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["print(train_data[0])\n","print(train_labels[0])\n","print(len(train_data))\n","print(len(test_data))"],"execution_count":0,"outputs":[]},{"metadata":{"id":"T9DdCQVQRlJQ","colab_type":"text"},"cell_type":"markdown","source":["### Converting the integers to words\n","\n","We can get the dictionary from `tf.keras.datasets.reuters.get_word_index` which hashes the words to their corresponding integers. Let's try and convert a newswire from integers back into it's original text by first reversing this dictionary and then iterating over a newswire and converting the integers to strings."]},{"metadata":{"id":"nVdKXJ7PRmUb","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["# Dictionary that hashes words to their integer\n","word_to_integer = tf.keras.datasets.reuters.get_word_index()"],"execution_count":0,"outputs":[]},{"metadata":{"id":"b8iedZIuRoIG","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["print(word_to_integer.keys()[0:10])\n","\n","integer_to_word = dict([(value, key) for (key, value) in word_to_integer.items()])\n","\n","# Demonstrate how to find the word from an integer\n","print(integer_to_word[1])\n","print(integer_to_word[2])\n","\n","import random\n","\n","random_index = random.randint(0, 100)\n","# We need to subtract 3 from the indices because 0 is \"padding\", 1 is \"start of sequence\", and 2 is \"unknown\"\n","decoded_newswire = ' '.join([integer_to_word.get(i - 3, 'UNK') for i in train_data[random_index]])\n","print(decoded_newswire)\n","print(train_labels[random_index])"],"execution_count":0,"outputs":[]},{"metadata":{"id":"NZYEERu2R0y1","colab_type":"text"},"cell_type":"markdown","source":["### Step 3) Format the data\n","As before, we are going to multi-hot encode our newswire which is an array of integers into a 10,000 dimensional vector. We will place 1's in the indices of word-integers that occur in the newswire, and 0's for everything else."]},{"metadata":{"id":"nbTtNYCIR4hs","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["def vectorize_sequences(sequences, dimension=10000):\n","    # Create an all-zero matrix of shape (len(sequences), dimension)\n","    results = np.zeros((len(sequences), dimension), dtype=np.float32)\n","    for i, sequence in enumerate(sequences):\n","        results[i, sequence] = 1.  # set specific indices of results[i] to 1s\n","    return results\n","\n","\n","train_data = vectorize_sequences(train_data)\n","test_data = vectorize_sequences(test_data)\n","\n","print(train_data.shape)\n","print(train_data[0])"],"execution_count":0,"outputs":[]},{"metadata":{"id":"MKo1m1ZrSELb","colab_type":"text"},"cell_type":"markdown","source":["### Step 4) Format the labels\n","\n","We will also use [tf.keras.utils.to_categorical](https://www.tensorflow.org/api_docs/python/tf/keras/utils/to_categorical) to one hot encode our labels."]},{"metadata":{"id":"b5Ew7zv-SJK-","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["LABEL_DIMENSIONS = 46\n","\n","print(train_labels[0]) # Before\n","train_labels  = tf.keras.utils.to_categorical(train_labels, LABEL_DIMENSIONS)\n","print(train_labels[0]) # After\n","\n","test_labels = tf.keras.utils.to_categorical(test_labels, LABEL_DIMENSIONS)\n","\n","# Needed later\n","train_labels = train_labels.astype(np.float32)\n","test_labels = test_labels.astype(np.float32)"],"execution_count":0,"outputs":[]},{"metadata":{"id":"mupgnRsQSa6k","colab_type":"text"},"cell_type":"markdown","source":["### Step 5) Create the model\n","\n","Our model is similar to the previous notebook, modified to work for a multiclass classification problem."]},{"metadata":{"id":"VLsDpdIoSaIU","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["### Create a model\n","model = tf.keras.Sequential()\n","\n","model.add(tf.keras.layers.Dense(64, activation=tf.nn.relu, input_shape=(10000,)))\n","model.add(tf.keras.layers.Dense(64, activation=tf.nn.relu))\n","model.add(tf.keras.layers.Dense(LABEL_DIMENSIONS, activation=tf.nn.softmax))\n","\n","optimizer = tf.train.RMSPropOptimizer(learning_rate=0.001)\n","\n","model.compile(loss='categorical_crossentropy',\n","              optimizer=optimizer,\n","              metrics=['accuracy'])\n","\n","model.summary()"],"execution_count":0,"outputs":[]},{"metadata":{"id":"E0KQorztSW0n","colab_type":"text"},"cell_type":"markdown","source":["### Step 6) Validation set\n","\n","As before, we want to test our model on data it hasn't seen before, but before we get our final test accuracy. Here, we'll create a validation set."]},{"metadata":{"id":"Ci6jFHB9TbWA","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["VAL_SIZE = 1000\n","\n","val_data = train_data[:VAL_SIZE]\n","partial_train_data = train_data[VAL_SIZE:]\n","\n","\n","val_labels = train_labels[:VAL_SIZE]\n","partial_train_labels = train_labels[VAL_SIZE:]"],"execution_count":0,"outputs":[]},{"metadata":{"id":"CaNEaxWkTkAE","colab_type":"text"},"cell_type":"markdown","source":["### Step 7) Create a tf.data Dataset"]},{"metadata":{"id":"Zx7aLE4vTnsS","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["BATCH_SIZE = 512\n","TRAINING_SIZE = partial_train_labels.shape[0]\n","\n","training_set = tf.data.Dataset.from_tensor_slices((partial_train_data, partial_train_labels))\n","training_set = training_set.shuffle(TRAINING_SIZE).batch(BATCH_SIZE)"],"execution_count":0,"outputs":[]},{"metadata":{"id":"W8S-IkYMTsHm","colab_type":"text"},"cell_type":"markdown","source":["### Step 8) Training your model\n","Please be patient as this step may take a while."]},{"metadata":{"id":"3OuvepxiTu7m","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["EPOCHS = 20\n","\n","# Store list of metric values for plotting later\n","tr_loss_list = []\n","tr_accuracy_list = []\n","val_loss_list = []\n","val_accuracy_list = []\n","\n","for epoch in range(EPOCHS):\n","  for (batch, (newswires, labels)) in enumerate(training_set):\n","    # Calculate training loss and accuracy\n","    tr_loss, tr_accuracy = model.train_on_batch(newswires, labels)\n","  \n","  # Calculate validation loss and accuracy\n","  val_loss, val_accuracy = model.evaluate(val_data, val_labels)\n","\n","  # Add to the lists\n","  tr_loss_list.append(tr_loss)\n","  tr_accuracy_list.append(tr_accuracy)\n","  val_loss_list.append(val_loss)\n","  val_accuracy_list.append(val_accuracy)\n","  \n","  print(('Epoch #%d\\t Training Loss: %.2f\\tTraining Accuracy: %.2f\\t'\n","         'Validation Loss: %.2f\\tValidation Accuracy: %.2f')\n","         % (epoch + 1, tr_loss, tr_accuracy,\n","         val_loss, val_accuracy))"],"execution_count":0,"outputs":[]},{"metadata":{"id":"TR0thBUhUDTb","colab_type":"text"},"cell_type":"markdown","source":["### Step 9) Plotting your loss and accuracy\n","We are going to use `matplotlib` to plot our training and validation metrics."]},{"metadata":{"id":"FEekeJKbTqj-","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["import matplotlib.pyplot as plt\n","\n","epochs = range(1, EPOCHS + 1)\n","\n","# \"bo\" specifies \"blue dot\"\n","plt.plot(epochs, tr_loss_list, 'bo', label='Training loss')\n","# b specifies a \"solid blue line\"\n","plt.plot(epochs, val_loss_list, 'b', label='Validation loss')\n","plt.title('Training and validation loss')\n","plt.xlabel('Epochs')\n","plt.ylabel('Loss')\n","plt.legend()\n","\n","plt.show()"],"execution_count":0,"outputs":[]},{"metadata":{"id":"XWybdzYEUE7p","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["plt.clf()   # Clear plot\n","\n","plt.plot(epochs, tr_accuracy_list, 'bo', label='Training accuracy')\n","plt.plot(epochs, val_accuracy_list, 'b', label='Validation accuracy')\n","plt.title('Training and validation accuracy')\n","plt.xlabel('Epochs')\n","plt.ylabel('Accuracy')\n","plt.legend()\n","\n","plt.show()"],"execution_count":0,"outputs":[]},{"metadata":{"id":"0UdrazksUI0_","colab_type":"text"},"cell_type":"markdown","source":["### Step 10) Testing your model\n","Now that we have successfully trained our model and our training accuracy has jumped over 90%, we need to test it. The test accuracy is a better evaluation metric for how our model will perform in the real world."]},{"metadata":{"id":"ta7jDHRwUGIa","colab_type":"code","colab":{"autoexec":{"startup":false,"wait_interval":0}}},"cell_type":"code","source":["loss, accuracy = model.evaluate(test_data, test_labels)\n","print('Test accuracy: %.2f' % (accuracy))"],"execution_count":0,"outputs":[]}]}
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "4-reuters.ipynb",
+      "version": "0.3.2",
+      "views": {},
+      "default_view": {},
+      "provenance": [],
+      "collapsed_sections": []
+    }
+  },
+  "cells": [
+    {
+      "metadata": {
+        "id": "j1bsrXvzxBbl",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "# Classifying newswires with tf.keras, tf.data, and eager execution.\n",
+        "\n",
+        "In this lab, you'll learn how to classify newswires from the [Reuters dataset](https://www.tensorflow.org/api_docs/python/tf/keras/datasets/reuters) into categories. This tutorial was inspired by [this one](https://github.com/fchollet/deep-learning-with-python-notebooks/blob/master/3.6-classifying-newswires.ipynb). This notebook is similar to previous one. The principal difference is here, we will explore a multiclass text classification problem.\n"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "fGBZG7rvwf2C",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "!pip install -q -U tensorflow==1.8.0\n",
+        "import tensorflow as tf\n",
+        "\n",
+        "# Enable eager execution\n",
+        "tf.enable_eager_execution()\n",
+        "\n",
+        "import numpy as np"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "_39NLiiGy9ey",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "\n",
+        "## A first look at the dataset\n",
+        "\n",
+        "### Step 1) Downloading the dataset\n",
+        "\n",
+        "The dataset consists of a set of short [newswires](https://www.google.com/search?q=what+is+a+newswire) and their corresponding topics as published by Reuters in 1986."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "F-DuuRzay9KG",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "(train_data, train_labels), (test_data, test_labels) = tf.keras.datasets.reuters.load_data(num_words=10000)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "arCrVEMGzR7t",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 2) Exploring the dataset \n",
+        "\n",
+        "There are around 46 different topics. The set is divided into 8982 training examples and 2246 test examples. Each training example is a list of words represented as integers similar to the IMDB dataset, and the labels are integers up to 46."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "KL6sMDLVzNpF",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "print(train_data[0])\n",
+        "print(train_labels[0])\n",
+        "print(len(train_data))\n",
+        "print(len(test_data))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "T9DdCQVQRlJQ",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Converting the integers to words\n",
+        "\n",
+        "We can get the dictionary from `tf.keras.datasets.reuters.get_word_index` which hashes the words to their corresponding integers. Let's try and convert a newswire from integers back into it's original text by first reversing this dictionary and then iterating over a newswire and converting the integers to strings."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "nVdKXJ7PRmUb",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "# Dictionary that hashes words to their integer\n",
+        "word_to_integer = tf.keras.datasets.reuters.get_word_index()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "b8iedZIuRoIG",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "print(word_to_integer.keys()[0:10])\n",
+        "\n",
+        "integer_to_word = dict([(value, key) for (key, value) in word_to_integer.items()])\n",
+        "\n",
+        "# Demonstrate how to find the word from an integer\n",
+        "print(integer_to_word[1])\n",
+        "print(integer_to_word[2])\n",
+        "\n",
+        "import random\n",
+        "\n",
+        "random_index = random.randint(0, 100)\n",
+        "# We need to subtract 3 from the indices because 0 is \"padding\", 1 is \"start of sequence\", and 2 is \"unknown\"\n",
+        "decoded_newswire = ' '.join([integer_to_word.get(i - 3, 'UNK') for i in train_data[random_index]])\n",
+        "print(decoded_newswire)\n",
+        "print(train_labels[random_index])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "NZYEERu2R0y1",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 3) Format the data\n",
+        "As before, we are going to multi-hot encode our newswire which is an array of integers into a 10,000 dimensional vector. We will place 1's in the indices of word-integers that occur in the newswire, and 0's for everything else."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "nbTtNYCIR4hs",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "def vectorize_sequences(sequences, dimension=10000):\n",
+        "    # Create an all-zero matrix of shape (len(sequences), dimension)\n",
+        "    results = np.zeros((len(sequences), dimension), dtype=np.float32)\n",
+        "    for i, sequence in enumerate(sequences):\n",
+        "        results[i, sequence] = 1.  # set specific indices of results[i] to 1s\n",
+        "    return results\n",
+        "\n",
+        "\n",
+        "train_data = vectorize_sequences(train_data)\n",
+        "test_data = vectorize_sequences(test_data)\n",
+        "\n",
+        "print(train_data.shape)\n",
+        "print(train_data[0])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "MKo1m1ZrSELb",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 4) Format the labels\n",
+        "\n",
+        "We will also use [tf.keras.utils.to_categorical](https://www.tensorflow.org/api_docs/python/tf/keras/utils/to_categorical) to one hot encode our labels."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "b5Ew7zv-SJK-",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "LABEL_DIMENSIONS = 46\n",
+        "\n",
+        "print(train_labels[0]) # Before\n",
+        "train_labels  = tf.keras.utils.to_categorical(train_labels, LABEL_DIMENSIONS)\n",
+        "print(train_labels[0]) # After\n",
+        "\n",
+        "test_labels = tf.keras.utils.to_categorical(test_labels, LABEL_DIMENSIONS)\n",
+        "\n",
+        "# Needed later\n",
+        "train_labels = train_labels.astype(np.float32)\n",
+        "test_labels = test_labels.astype(np.float32)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "mupgnRsQSa6k",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 5) Create the model\n",
+        "\n",
+        "Our model is similar to the previous notebook, modified to work for a multiclass classification problem."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "VLsDpdIoSaIU",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "### Create a model\n",
+        "model = tf.keras.Sequential()\n",
+        "\n",
+        "model.add(tf.keras.layers.Dense(64, activation=tf.nn.relu, input_shape=(10000,)))\n",
+        "model.add(tf.keras.layers.Dense(64, activation=tf.nn.relu))\n",
+        "model.add(tf.keras.layers.Dense(LABEL_DIMENSIONS, activation=tf.nn.softmax))\n",
+        "\n",
+        "optimizer = tf.train.RMSPropOptimizer(learning_rate=0.001)\n",
+        "\n",
+        "model.compile(loss='categorical_crossentropy',\n",
+        "              optimizer=optimizer,\n",
+        "              metrics=['accuracy'])\n",
+        "\n",
+        "model.summary()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "E0KQorztSW0n",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 6) Validation set\n",
+        "\n",
+        "As before, we want to test our model on data it hasn't seen before, but before we get our final test accuracy. Here, we'll create a validation set."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "Ci6jFHB9TbWA",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "VAL_SIZE = 1000\n",
+        "\n",
+        "val_data = train_data[:VAL_SIZE]\n",
+        "partial_train_data = train_data[VAL_SIZE:]\n",
+        "\n",
+        "\n",
+        "val_labels = train_labels[:VAL_SIZE]\n",
+        "partial_train_labels = train_labels[VAL_SIZE:]"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "CaNEaxWkTkAE",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 7) Create a tf.data Dataset"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "Zx7aLE4vTnsS",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "BATCH_SIZE = 512\n",
+        "TRAINING_SIZE = partial_train_labels.shape[0]\n",
+        "\n",
+        "training_set = tf.data.Dataset.from_tensor_slices((partial_train_data, partial_train_labels))\n",
+        "training_set = training_set.shuffle(TRAINING_SIZE).batch(BATCH_SIZE)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "W8S-IkYMTsHm",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 8) Training your model\n",
+        "Please be patient as this step may take a while."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "3OuvepxiTu7m",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "EPOCHS = 20\n",
+        "\n",
+        "# Store list of metric values for plotting later\n",
+        "tr_loss_list = []\n",
+        "tr_accuracy_list = []\n",
+        "val_loss_list = []\n",
+        "val_accuracy_list = []\n",
+        "\n",
+        "for epoch in range(EPOCHS):\n",
+        "  for newswires, labels in training_set:\n",
+        "    # Calculate training loss and accuracy\n",
+        "    tr_loss, tr_accuracy = model.train_on_batch(newswires, labels)\n",
+        "  \n",
+        "  # Calculate validation loss and accuracy\n",
+        "  val_loss, val_accuracy = model.evaluate(val_data, val_labels)\n",
+        "\n",
+        "  # Add to the lists\n",
+        "  tr_loss_list.append(tr_loss)\n",
+        "  tr_accuracy_list.append(tr_accuracy)\n",
+        "  val_loss_list.append(val_loss)\n",
+        "  val_accuracy_list.append(val_accuracy)\n",
+        "  \n",
+        "  print(('Epoch #%d\\t Training Loss: %.2f\\tTraining Accuracy: %.2f\\t'\n",
+        "         'Validation Loss: %.2f\\tValidation Accuracy: %.2f')\n",
+        "         % (epoch + 1, tr_loss, tr_accuracy,\n",
+        "         val_loss, val_accuracy))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "TR0thBUhUDTb",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 9) Plotting your loss and accuracy\n",
+        "We are going to use `matplotlib` to plot our training and validation metrics."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "FEekeJKbTqj-",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "epochs = range(1, EPOCHS + 1)\n",
+        "\n",
+        "# \"bo\" specifies \"blue dot\"\n",
+        "plt.plot(epochs, tr_loss_list, 'bo', label='Training loss')\n",
+        "# b specifies a \"solid blue line\"\n",
+        "plt.plot(epochs, val_loss_list, 'b', label='Validation loss')\n",
+        "plt.title('Training and validation loss')\n",
+        "plt.xlabel('Epochs')\n",
+        "plt.ylabel('Loss')\n",
+        "plt.legend()\n",
+        "\n",
+        "plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "XWybdzYEUE7p",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "plt.clf()   # Clear plot\n",
+        "\n",
+        "plt.plot(epochs, tr_accuracy_list, 'bo', label='Training accuracy')\n",
+        "plt.plot(epochs, val_accuracy_list, 'b', label='Validation accuracy')\n",
+        "plt.title('Training and validation accuracy')\n",
+        "plt.xlabel('Epochs')\n",
+        "plt.ylabel('Accuracy')\n",
+        "plt.legend()\n",
+        "\n",
+        "plt.show()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "0UdrazksUI0_",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "### Step 10) Testing your model\n",
+        "Now that we have successfully trained our model and our training accuracy has jumped over 90%, we need to test it. The test accuracy is a better evaluation metric for how our model will perform in the real world."
+      ]
+    },
+    {
+      "metadata": {
+        "id": "ta7jDHRwUGIa",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "loss, accuracy = model.evaluate(test_data, test_labels)\n",
+        "print('Test accuracy: %.2f' % (accuracy))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
As if 1.8, Datasets in eager no longer require `enumerate` for iteration. Where `batch` isn't required, this PR changes:
```
for (batch, (images, labels)) in enumerate(dataset):
```
to:
```
for images, labels in dataset:
```
Which is what the tf.org guide now uses.

Unfortunately, the JSON output of these notebooks was previously saved without formatting, which means git can't keep track of these small changes. (Though save-with-formatting seems to be the default when saving from colab.) If you prefer to reformat and apply these changes yourself, I won't take offense.

View here:
2: https://colab.sandbox.google.com/github/lamberta/workshops/blob/ebc50bf52844637e0b29978cd83e5364d522e840/notebooks/2-mnist-with-keras-eager-and-tf-data.ipynb
3: https://colab.sandbox.google.com/github/lamberta/workshops/blob/ebc50bf52844637e0b29978cd83e5364d522e840/notebooks/3-imdb.ipynb
4: https://colab.sandbox.google.com/github/lamberta/workshops/blob/ebc50bf52844637e0b29978cd83e5364d522e840/notebooks/4-reuters.ipynb
